### PR TITLE
Proposal: passing arguments to backends

### DIFF
--- a/include/interflop.h
+++ b/include/interflop.h
@@ -1,19 +1,31 @@
 /* interflop backend interface */
 
 struct interflop_backend_interface_t {
-  void (*interflop_add_float)(float, float, float*, void*);
-  void (*interflop_sub_float)(float, float, float*, void*);
-  void (*interflop_mul_float)(float, float, float*, void*);
-  void (*interflop_div_float)(float, float, float*, void*);
+  void (*interflop_add_float)(float a, float b, float *c, void *context);
+  void (*interflop_sub_float)(float a, float b, float *c, void *context);
+  void (*interflop_mul_float)(float a, float b, float *c, void *context);
+  void (*interflop_div_float)(float a, float b, float *c, void *context);
 
-  void (*interflop_add_double)(double, double, double*, void*);
-  void (*interflop_sub_double)(double, double, double*, void*);
-  void (*interflop_mul_double)(double, double, double*, void*);
-  void (*interflop_div_double)(double, double, double*, void*);
+  void (*interflop_add_double)(double a, double b, double *c, void *context);
+  void (*interflop_sub_double)(double a, double b, double *c, void *context);
+  void (*interflop_mul_double)(double a, double b, double *c, void *context);
+  void (*interflop_div_double)(double a, double b, double *c, void *context);
 };
 
 /* interflop_init: called at initialization before using a backend.
  * It returns an interflop_backend_interface_t structure with callbacks
- * for each of the numerical instrument hooks */
+ * for each of the numerical instrument hooks.
+ *
+ * argc: number of arguments passed to the backend
+ *
+ * argv: arguments passed to the backend, argv[0] always contains the name of
+ * the backend library. argv[] may be deallocated after the call to
+ * interflop_init. To make it persistent, a backend must copy it.
+ *
+ * context: the backend is free to make this point to a backend-specific
+ * context. The frontend will pass the context back as the last argument of the
+ * above instrumentation hooks.
+ * */
 
-struct interflop_backend_interface_t interflop_init(void ** context);
+struct interflop_backend_interface_t interflop_init(int argc, char **argv,
+                                                    void **context);


### PR DESCRIPTION
Verificarlo is preparing to move fully towards the interflop interface (verificarlo/verificarlo#93).

In this context we need a way to pass arguments and options to our backends. For example, the mca or random-rounding backends require options to configure the precision or rounding mode.

This is a proposal to pass arguments to the backends by adding two parameters to the interflop_init function with the following conventions,

```c
/* interflop_init: called at initialization before using a backend.
 * It returns an interflop_backend_interface_t structure with callbacks
 * for each of the numerical instrument hooks.
 *
 * argc: number of arguments passed to the backend
 *
 * argv: arguments passed to the backend, argv[0] always contains the name of
 * the backend library. argv[] may be deallocated after the call to
 * interflop_init. To make it persistent, a backend must copy it.
 *
 * context: the backend is free to make this point to a backend-specific
 * context. The frontend will pass the context back as the last argument of the
 * above instrumentation hooks.
 * */

struct interflop_backend_interface_t interflop_init(int argc, char **argv,
                                                    void **context);
```
In this way, earch argument is free to parse argc, argv using well established libraries (such as `argp.h`). See example [here in the ongoing verificarlo's interflop PR](https://github.com/verificarlo/verificarlo/pull/93/files#diff-822f423b43c6f5a11506da70b7eb365dR196).

In this PR, I have only modified `interflop.h` to start the discussion. If this proposal is accepted, we should update the existing backends and the C++ interface before merging.