### PR TITLE
Proposal: add hooks for floating point comparisons

### DIFF
--- a/include/interflop.h
+++ b/include/interflop.h
@@ -1,15 +1,40 @@
 /* interflop backend interface */
 
-struct interflop_backend_interface_t {
-  void (*interflop_add_float)(float, float, float*, void*);
-  void (*interflop_sub_float)(float, float, float*, void*);
-  void (*interflop_mul_float)(float, float, float*, void*);
-  void (*interflop_div_float)(float, float, float*, void*);
+/* interflop float compare predicates, follows the same order than
+ * LLVM's FCMPInstruction predicates */
+enum FCMP_PREDICATE {
+  FCMP_FALSE,
+  FCMP_OEQ,
+  FCMP_OGT,
+  FCMP_OGE,
+  FCMP_OLT,
+  FCMP_OLE,
+  FCMP_ONE,
+  FCMP_ORD,
+  FCMP_UNO,
+  FCMP_UEQ,
+  FCMP_UGT,
+  FCMP_UGE,
+  FCMP_ULT,
+  FCMP_ULE,
+  FCMP_UNE,
+  FCMP_TRUE,
+};
 
-  void (*interflop_add_double)(double, double, double*, void*);
-  void (*interflop_sub_double)(double, double, double*, void*);
-  void (*interflop_mul_double)(double, double, double*, void*);
-  void (*interflop_div_double)(double, double, double*, void*);
+struct interflop_backend_interface_t {
+  void (*interflop_add_float)(float a, float b, float *c, void *context);
+  void (*interflop_sub_float)(float a, float b, float *c, void *context);
+  void (*interflop_mul_float)(float a, float b, float *c, void *context);
+  void (*interflop_div_float)(float a, float b, float *c, void *context);
+  void (*interflop_cmp_float)(enum FCMP_PREDICATE p, float a, float b, int *c,
+                              void *context);
+
+  void (*interflop_add_double)(double a, double b, double *c, void *context);
+  void (*interflop_sub_double)(double a, double b, double *c, void *context);
+  void (*interflop_mul_double)(double a, double b, double *c, void *context);
+  void (*interflop_div_double)(double a, double b, double *c, void *context);
+  void (*interflop_cmp_double)(enum FCMP_PREDICATE p, double a, double b, int *c,
+                               void *context);
 };
 
 /* interflop_init: called at initialization before using a backend.


### PR DESCRIPTION
Verificarlo is preparing to move fully towards the interflop interface (verificarlo/verificarlo#93).

In this context we would like to instrument floating point comparisons (fcmp).

This is a proposal to add two hooks to `interflop.h` with the following conventions,

```c
/* interflop float compare predicates, follows the same order than
 * LLVM's FCMPInstruction predicates */
enum FCMP_PREDICATE {
  FCMP_FALSE,
  FCMP_OEQ,
  FCMP_OGT,
  FCMP_OGE,
  FCMP_OLT,
  FCMP_OLE,
  FCMP_ONE,
  FCMP_ORD,
  FCMP_UNO,
  FCMP_UEQ,
  FCMP_UGT,
  FCMP_UGE,
  FCMP_ULT,
  FCMP_ULE,
  FCMP_UNE,
  FCMP_TRUE,
};

struct interflop_backend_interface_t {
  // [...]
  void (*interflop_cmp_float)(enum FCMP_PREDICATE p, float a, float b, int *c,
                              void *context);
  // [...]
  void (*interflop_cmp_double)(enum FCMP_PREDICATE p, double a, double b, int *c,
                               void *context);
};
```

The enumeration `FCMP_PREDICATE` contains the 16 floating point [operators supported by LLVM](https://llvm.org/docs/LangRef.html#fcmp-instruction). We think it is better to have only two hooks predicated with the enum, instead of 32 individual hooks (16 for float and 16 for double).

Since we are mainly using the LLVM frontend, this is very practical for us. But we are flexible if another representation is more general or practical.

In this PR, I have only modified `interflop.h` to start the discussion. If this proposal is accepted, we should update the existing backends and the C++ interface before merging.